### PR TITLE
add build folder to cache volume

### DIFF
--- a/docusaurus/dagger/main.go
+++ b/docusaurus/dagger/main.go
@@ -72,6 +72,10 @@ func (m *Docusaurus) Base() *Container {
 				dag.CacheVolume(m.CacheVolumeName),
 			).
 			WithMountedCache(
+				fmt.Sprintf("%s/build", m.Dir),
+				dag.CacheVolume(m.CacheVolumeName),
+			).
+			WithMountedCache(
 				"/root/.npm",
 				dag.CacheVolume("node-docusaurus-root"),
 			)


### PR DESCRIPTION
this helps speeding up docusaurus builds to avoid re-compiling everything each time