### PR TITLE
fix(docusaurus): accept local dir instead of absolute

### DIFF
--- a/docusaurus/dagger/main.go
+++ b/docusaurus/dagger/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"dagger/docusaurus/internal/dagger"
 	"fmt"
+	"path/filepath"
 )
 
 func New(
@@ -29,7 +30,7 @@ func New(
 	src *dagger.Directory,
 	// Optional working directory if you need to execute docusaurus commands outside of your root
 	// +optional
-	// +default="/src"
+	// +default="."
 	dir string,
 	// Optional flag to disable cache
 	// +optional
@@ -71,7 +72,7 @@ func (m *Docusaurus) Base() *dagger.Container {
 		From("node:lts-alpine").
 		WithoutEntrypoint().
 		WithMountedDirectory("/src", m.Src).
-		WithWorkdir(m.Dir)
+		WithWorkdir(filepath.Join("/src", m.Dir))
 
 	if !m.DisableCache {
 		ctr = ctr.


### PR DESCRIPTION
Setting this use to require that the caller know about `/src` being the mount point - this is kind of annoying, so instead we should set it to be local to `/src`. Then the user just needs the relative path in the directory that they pass in.