### PR TITLE
Fixes for docusaurus caching

### DIFF
--- a/docusaurus/dagger/main.go
+++ b/docusaurus/dagger/main.go
@@ -78,6 +78,9 @@ func (m *Docusaurus) Base() *dagger.Container {
 			WithMountedCache(
 				fmt.Sprintf("%s/build", m.Dir),
 				dag.CacheVolume(m.CacheVolumeName+"-build"),
+				dagger.ContainerWithMountedCacheOpts{
+					Sharing: dagger.CacheSharingModePrivate,
+				},
 			).
 			WithMountedCache(
 				"/root/.npm",

--- a/docusaurus/dagger/main.go
+++ b/docusaurus/dagger/main.go
@@ -76,10 +76,6 @@ func (m *Docusaurus) Base() *dagger.Container {
 	if !m.DisableCache {
 		ctr = ctr.
 			WithMountedCache(
-				fmt.Sprintf("%s/node_modules", m.Dir),
-				dag.CacheVolume(m.CacheVolumeName),
-			).
-			WithMountedCache(
 				fmt.Sprintf("%s/build", m.Dir),
 				dag.CacheVolume(m.CacheVolumeName+"-build"),
 			).


### PR DESCRIPTION
- Remove cache volume for node_modules. This isn't needed (and can actually result in some weird correctness problems) - we should instead cache volume the global package cache.
- Keep docs build cache volume private. This avoids some wacky race conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated container setup to remove caching for the node_modules directory.
  - Adjusted cache settings for the build directory to use private sharing mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->